### PR TITLE
Added TestRPC as a dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,5 +22,8 @@
   "bugs": {
     "url": "https://github.com/gnosis/run-with-testrpc/issues"
   },
-  "homepage": "https://github.com/gnosis/run-with-testrpc#readme"
+  "homepage": "https://github.com/gnosis/run-with-testrpc#readme",
+  "dependencies": {
+    "ethereumjs-testrpc": "^4.1.1"
+  }
 }


### PR DESCRIPTION
Should resolve https://github.com/gnosis/run-with-testrpc/issues/1

I think originally I didn't add this as a requirement because this module can technically be used with the `testrpc-sc` fork, for example. However, in the overwhelming majority of cases, I'd guess that the regular TestRPC is desired. So here it is as a dependency.