### PR TITLE
Made errors clearer, less noisy

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -308,6 +308,11 @@
       "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
       "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c="
     },
+    "colors": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/colors/-/colors-1.1.2.tgz",
+      "integrity": "sha1-FopHAXVran9RoSzgyXv6KMCE7WM="
+    },
     "concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
   },
   "homepage": "https://github.com/gnosis/run-with-testrpc#readme",
   "dependencies": {
+    "colors": "^1.1.2",
     "ethereumjs-testrpc": "^4.1.1"
   }
 }


### PR DESCRIPTION
See: https://github.com/gnosis/run-with-testrpc/issues/3 for an example of what it used to be like. Now looks like this:

![better-run-with-testrpc](https://user-images.githubusercontent.com/298447/33100026-89612e4c-ced8-11e7-8b1d-c6db240a5073.png)
